### PR TITLE
Make tags sortable via drag, fix #20

### DIFF
--- a/components/Forms/Inputs/TagsInput/TagsInput--with-autocomplete.hbs
+++ b/components/Forms/Inputs/TagsInput/TagsInput--with-autocomplete.hbs
@@ -1,4 +1,4 @@
 <kirby-tags-input :autocomplete="{
   url: '/mock/data/countries.json',
   map: {value: 'name', text: 'name'}
-}" />
+}" :sortable="false" />

--- a/components/Forms/Inputs/TagsInput/TagsInput.vue
+++ b/components/Forms/Inputs/TagsInput/TagsInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="kirby-tags-input">
+  <draggable v-model="tags" :options="{disabled: !sortable}" class="kirby-tags-input">
     <kirby-tag v-for="tag in tags"
       :ref="tag"
       :key="tag"
@@ -11,7 +11,7 @@
       :removable="true">
         {{ tag }}
     </kirby-tag>
-    <span class="kirby-tags-input-element">
+    <span slot="footer" class="kirby-tags-input-element">
       <kirby-autocomplete v-if="autocomplete"
         ref="input"
         :id="id"
@@ -28,20 +28,31 @@
         @keydown.left="leaveInput"
         @keydown.delete="leaveInput">
     </span>
-  </div>
+  </draggable>
 </template>
 
 <script>
 
+import draggable from 'vuedraggable'
 import Autocomplete from 'Forms/Autocomplete/Autocomplete.vue';
 import Tag from 'Buttons/Tag/Tag.vue';
 
 export default {
   components: {
+    draggable,
     'kirby-autocomplete': Autocomplete,
     'kirby-tag': Tag
   },
-  props: ['id', 'value', 'required', 'autofocus', 'autocomplete'],
+  props: {
+    'id': {},
+    'value': {},
+    'required': {},
+    'autofocus': {},
+    'autocomplete': {},
+    'sortable': {
+      default: true
+    }
+  },
   data: function() {
 
     var tags = this.value || [];
@@ -180,6 +191,9 @@ export default {
 .kirby-tags-input .kirby-tag {
   margin-right: 4px;
   margin-bottom: 4px;
+}
+.kirby-tags-input .kirby-tag.sortable-ghost {
+  opacity: .2;
 }
 .kirby-tags-input-element input {
   display: inline-block;

--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 
+/** Vendor **/
+import draggable from 'vuedraggable'
+
 /** Bars **/
 import Bar from 'Bars/Bar/Bar.vue'
 
@@ -164,7 +167,7 @@ new Vue({
     'kirby-header': Header,
     'kirby-column': Column,
     'kirby-view': View,
-    
+
     /** Table **/
     'kirby-table': Table,
     'kirby-table-row': TableRow,
@@ -172,7 +175,7 @@ new Vue({
     'kirby-table-header': TableHeader,
     'kirby-table-header-cell': TableHeaderCell,
     'kirby-table-body': TableBody,
-     
+
     /** Navigation **/
     'kirby-breadcrumb': Breadcrumb,
     'kirby-breadcrumb-item': BreadcrumbItem,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@frctl/fractal": "^1.1.4",
     "vue": "^2.3.3",
-    "vue-router": "^2.5.3"
+    "vue-router": "^2.5.3",
+    "vuedraggable": "^2.14.1"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",


### PR DESCRIPTION
Built using https://github.com/SortableJS/Vue.Draggable

![kapture 2017-08-07 at 10 42 24](https://user-images.githubusercontent.com/3788865/29021456-d570a176-7b65-11e7-8ed8-dc2f6f1a0f66.gif)